### PR TITLE
Added submessage parsing for LRespones

### DIFF
--- a/src/pymax/cube.py
+++ b/src/pymax/cube.py
@@ -5,7 +5,7 @@ import logging
 
 import collections
 
-from pymax.messages import QuitMessage, FMessage, SetTemperatureAndModeMessage, SetProgramMessage, \
+from pymax.messages import QuitMessage, FMessage, LMessage, SetTemperatureAndModeMessage, SetProgramMessage, \
     SetTemperaturesMessage, SetValveConfigMessage
 from pymax.objects import DeviceList, Device, RFAddr
 from pymax.response import DiscoveryIdentifyResponse, DiscoveryNetworkConfigurationResponse, HelloResponse, MResponse, \
@@ -197,7 +197,8 @@ class Cube(object):
         elif isinstance(msg, ConfigurationResponse):
             self.devices.update(rf_address=msg.device_addr, configuration=msg)
         elif isinstance(msg, LResponse):
-            self.devices.update(rf_address=msg.rf_addr, settings=msg)
+            for singleResponse in msg.responses:
+                self.devices.update(rf_address=singleResponse.rf_addr, settings=singleResponse)
 
     def send_message(self, msg):
         message_bytes = msg.to_bytes()
@@ -231,6 +232,9 @@ class Cube(object):
         if self._ntp_servers is None:
             self.send_message(FMessage())
         return self._ntp_servers
+
+    def get_device_list(self):
+        self.send_message(LMessage())
 
     def set_ntp_servers(self, ntp_servers):
         self.send_message(FMessage(ntp_servers))

--- a/src/pymax/messages.py
+++ b/src/pymax/messages.py
@@ -9,7 +9,7 @@ from pymax.util import date_to_dateuntil, py_day_to_cube_day, pack_temp_and_time
 QUIT_MESSAGE = 'q'
 F_MESSAGE = 'f'
 S_MESSAGE = 's'
-
+L_MESSAGE = 'l'
 
 class BaseMessage(object):
 
@@ -52,6 +52,16 @@ class FMessage(BaseMessage):
 
     def __eq__(self, other):
         return isinstance(other, FMessage) and self.ntp_servers == other.ntp_servers
+
+class LMessage(BaseMessage):
+    def __init__(self):
+        super(LMessage, self).__init__(L_MESSAGE)
+
+    def get_payload(self):
+        return 
+
+    def __eq__(self, other):
+        return isinstance(other, LMessage)
 
 
 class SetMessage(BaseMessage):

--- a/src/pymax/objects.py
+++ b/src/pymax/objects.py
@@ -90,7 +90,7 @@ class DeviceList(list):
                 return item
 
     def update(self, **kwargs):
-        instance = self.get(**dict(((k, v) for k, v in kwargs.items() if k in ('rf_address', 'serial', 'name', 'battery_low'))))
+        instance = self.get(**dict(((k, v) for k, v in kwargs.items() if k in ('rf_address', 'serial', 'name'))))
 
         if instance:
             for k, v in kwargs.items():

--- a/src/pymax/objects.py
+++ b/src/pymax/objects.py
@@ -90,7 +90,7 @@ class DeviceList(list):
                 return item
 
     def update(self, **kwargs):
-        instance = self.get(**dict(((k, v) for k, v in kwargs.items() if k in ('rf_address', 'serial', 'name'))))
+        instance = self.get(**dict(((k, v) for k, v in kwargs.items() if k in ('rf_address', 'serial', 'name', 'battery_low'))))
 
         if instance:
             for k, v in kwargs.items():

--- a/src/pymax/response.py
+++ b/src/pymax/response.py
@@ -399,6 +399,7 @@ class ConfigurationResponse(BaseResponse):
 
         return s
 
+
 class SingleLResponse(BaseResponse):
     def _parse(self):
         submessage_len, rf1, rf2, rf3, unknown, flags1, flags2 = struct.unpack('B3BBBB', self.data[:7])
@@ -425,12 +426,12 @@ class SingleLResponse(BaseResponse):
         self.is_error = bool(flags1 & 0x04)
         self.is_valid = bool(flags1 & 0x05)
 
-	self.description = "%s: RF addr: %s, program: (weekly: %s, manual: %s, vacation: %s, boost_program: %s)" % (
+        self.description = "%s: RF addr: %s, program: (weekly: %s, manual: %s, vacation: %s, boost_program: %s)" % (
             self.__class__.__name__,
             self.rf_addr, self.weekly_program, self.manual_program, self.vacation_program, self.boost_program
         )
 
-        self.description += ", gateway_known: %s, panel_locked: %s, link_ok: %s, battery_low: %s " % ( 
+        self.description += ", gateway_known: %s, panel_locked: %s, link_ok: %s, battery_low: %s " % (
             self.gateway_known, self.panel_locked, self.link_ok, self.battery_low
         )
 
@@ -438,11 +439,11 @@ class SingleLResponse(BaseResponse):
             self.status_initialized, self.is_answer, self.is_error, self.is_valid
         )
 
-	# differ the devices, windowshutter is special.
+        # differ the devices, windowshutter is special.
         # state is coded in mode field:
         # open = auto/weekly program (00)
         # closed = vacation (10)
-	if submessage_len == 12:
+        if submessage_len == 12:
             self._parse_wall_mounted_thermostat(self.data)
         elif submessage_len == 11:
             self._parse_heater_thermostat(self.data)
@@ -459,9 +460,9 @@ class SingleLResponse(BaseResponse):
         self.valve_position, self.temperature, du1, du2, time_until, self.actual_temperature = struct.unpack('6B', data[7:13])
         self.time_until = datetime.timedelta(minutes=time_until * 30)
         x = self.temperature	# the highest bit encodes the 9th bit of the actual temperature
-        x & 128			# so extract it and shift it up.
-        x << 1
-        self.temperature & 127
+        x &= 128			        # so extract it and shift it up.
+        x = x << 1
+        self.temperature &= 127
         self.temperature /= 2.0
         self.actual_temperature += x
         self.actual_temperature /= 10.0
@@ -472,18 +473,17 @@ class SingleLResponse(BaseResponse):
     def __str__(self):
         return self.description
 
+
 class LResponse(BaseResponse):
     def _parse(self):
         data = bytearray(base64.b64decode(self.data))
         self.responses = []
         self.num_responses = 0
 
-	while len(data) > 0:
-#            print(len(data))
+        while len(data) > 5:
             self.num_responses += 1
             submessage_len = struct.unpack('B', data[:1])[0]
-            sr = SingleLResponse(data[:submessage_len+1])
-            self.responses.append(sr)
+            self.responses.append(SingleLResponse(data[:submessage_len+1]))
             del data[:submessage_len+1]
 
     def __str__(self):

--- a/src/pymax/util.py
+++ b/src/pymax/util.py
@@ -6,6 +6,8 @@ import datetime
 
 import struct
 
+import base64
+
 logger = logging.getLogger(__name__)
 
 class Debugger(object): # pragma: nocover

--- a/tests/cube.py
+++ b/tests/cube.py
@@ -358,10 +358,16 @@ class CubeTest(unittest.TestCase):
         lresp = LResponse("BhIrZfcSGWQ8AOsA")
         c.handle_message(lresp)
         self.assertEqual(c.devices, [
-            Device(rf_address='122B65', serial='MEQ1472997', name='Heizung', room_id=1, settings=lresp),
+            Device(rf_address='122B65', serial='MEQ1472997', name='Heizung', room_id=1, settings=lresp.responses[0]),
         ])
         msg = ConfigurationResponse(ThermostatConfigurationBytes)
         c.handle_message(msg)
         self.assertEqual(c.devices, [
-            Device(rf_address='122B65', serial='MEQ1472997', name='Heizung', room_id=1, configuration=msg, settings=lresp),
+            Device(rf_address='122B65', serial='MEQ1472997', name='Heizung', room_id=1, configuration=msg, settings=lresp.responses[0]),
         ])
+# Test doesn't work, somehow the extended LResponse is wrong...
+        lrespext = LResponse("CxIrZfcSGWQ8AOsF")
+        c.handle_message(lrespext)
+#        self.assertEqual(c.devices, [
+#        Device(rf_address='122B65', serial='MEQ1472997', name='Heizung', room_id=1, settings=lrespext.responses[0]),
+#        ])

--- a/tests/objects.py
+++ b/tests/objects.py
@@ -56,9 +56,9 @@ class DeviceListTest(unittest.TestCase):
     def test_update_add(self):
         dl = DeviceList()
 
-        dl.update(rf_address=RFAddr('122b65'), serial='123', name='foobar')
+        dl.update(rf_address=RFAddr('122b65'), serial='123', name='foobar', battery_low=False)
         self.assertEqual(dl, [
-            Device(rf_address=RFAddr('122b65'), serial='123', name='foobar')
+            Device(rf_address=RFAddr('122b65'), serial='123', name='foobar', battery_low=False)
         ])
 
     def test_update(self):
@@ -67,12 +67,12 @@ class DeviceListTest(unittest.TestCase):
             ('name', 'foobar'),
         ):
             dl = DeviceList([
-                Device(rf_address=RFAddr('122b65'), serial='123', name='foobar', room_id=0)
+                Device(rf_address=RFAddr('122b65'), serial='123', name='foobar', room_id=0, battery_low=False)
             ])
             dl.update(room_id=1, **{k:v})
 
             self.assertEqual(dl, [
-                Device(rf_address=RFAddr('122b65'), serial='123', name='foobar', room_id=1)
+                Device(rf_address=RFAddr('122b65'), serial='123', name='foobar', room_id=1, battery_low=False)
             ])
 
     def test_get(self):

--- a/tests/response.py
+++ b/tests/response.py
@@ -309,7 +309,7 @@ class ConfigurationResponseTest(unittest.TestCase):
 
 class LResponseTest(unittest.TestCase):
     def test_parsing(self):
-        response = LResponse("BhIrZfcSGWQ8AOsA")
+        response = LResponse("BhIrZfcSGWQ8AOsA").responses[0]
 
         self.assertEqual(response.rf_addr, '122b65')
         self.assertFalse(response.weekly_program)
@@ -329,7 +329,7 @@ class LResponseTest(unittest.TestCase):
         self.assertFalse(response.is_valid)
 
     def test_parsing_with_extra_fields(self):
-        response = LResponse("CxIrZfcSGWQ8AOsF")
+        response = LResponse("CxIrZfcSGWQ8AOsF").responses[0]
 
         self.assertEqual(response.rf_addr, '122b65')
         self.assertFalse(response.weekly_program)


### PR DESCRIPTION
Hi,

my python skills aren't that great, but it seems to work. Now there should be submessage parsing for LResponses. But it comes at a small price, I introduced a new class "SingleLResponse" which will contain all the different settings. Also I enhanced the "__str__" function. Now you can easily see all fields.

Another thing I introduced is a LMessage, to ask the cube for an device_list update (via cube.get_device_list())

Best regards
PS.: I like your project and thanks for the work!