### PR TITLE
Adjusted RF flags field from 04 (room) to 00 (device) specific.

### DIFF
--- a/src/pymax/messages.py
+++ b/src/pymax/messages.py
@@ -67,7 +67,7 @@ class LMessage(BaseMessage):
 class SetMessage(BaseMessage):
     base64payload = True
 
-    TemperatureAndMode = 0x440000000
+    TemperatureAndMode = 0x040000000 # Changed RF flags from 0x04 to 0x00 to address device vice a room (which set valves randomly) - see https://github.com/Bouni/max-cube-protocol/blob/master/S-Message.md
     Program = 0x410000000
     Temperatures = 0x11000000
     ValveConfig = 0x0412000000


### PR DESCRIPTION
Using RF flags 04 set multiple random valves which weren't in that room.  Not sure why there is an option to set by room when you have to specify device RFaddr anyway?  Using RF flags 00 (https://github.com/Bouni/max-cube-protocol/blob/master/S-Message.md#rf-flags) addresses the device directly and works as expected.