### PR TITLE
Fix connecting to Cube

### DIFF
--- a/src/pymax/cube.py
+++ b/src/pymax/cube.py
@@ -114,7 +114,11 @@ class Cube(object):
     def _create_socket(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(1)
-        s.connect(self.addr_port)
+        try:
+            s.connect(self.addr_port)
+        except:
+            s.close()
+            raise
         return s
 
     def disconnect(self):


### PR DESCRIPTION
Closing socket explicitly in case of unsuccessful connection. Socket in original version stay open in SYN_SENT state after timeout exception preventing next connection to Cube.